### PR TITLE
Unescape Slack control characters before sending to OpenAI

### DIFF
--- a/internals.py
+++ b/internals.py
@@ -18,6 +18,13 @@ GPT_3_5_TURBO_0301_MODEL = "gpt-3.5-turbo-0301"
 def call_openai(
     api_key: str, messages: List[Dict[str, str]], user: str, logger: logging.Logger
 ):
+    # Unescape &, < and >, since Slack replaces these with their HTML equivalents
+    # See also: https://api.slack.com/reference/surfaces/formatting#escaping
+    for message in messages:
+        message["content"] = message["content"].replace("&lt;", "<")
+        message["content"] = message["content"].replace("&gt;", ">")
+        message["content"] = message["content"].replace("&amp;", "&")
+
     # Remove old user messages to make sure we have room for max_tokens
     # See also: https://platform.openai.com/docs/guides/chat/introduction
     # > total tokens must be below the model’s maximum limit (4096 tokens for gpt-3.5-turbo-0301)


### PR DESCRIPTION
Slack uses `&`, `<` and `>` as control characters, which are replaced with their HTML equivalents (see https://api.slack.com/reference/surfaces/formatting#escaping). This can problems when asking ChatGPT about code, even when these characters appear within code blocks, e.g.,
**Prompt**: Is anything wrong with the angle brackets in the following C code?
```c
#include <stdio.h>
int main(int argc, char *argv[])
{
    printf("Hello, world!\n");
    return 0;
}
```

**Example response without this PR**: Yes, there is something wrong with the angle brackets in the code. C code should use the normal angle brackets "<" and ">" for including header files. In the code you shared, "<" and ">" entities have been used instead of the normal angle brackets. This is likely due to HTML encoding, which means that the code has been copied from an HTML document where the angle brackets were replaced with those entities to prevent them from being interpreted as HTML tags. To fix it, replace "<" with "<" and ">" with ">" in the #include line.

**Example response with this PR**: No, there is nothing wrong with the usage of angle brackets in the code. The angle brackets are used to include standard libraries in C, in this case, `stdio.h`.