### PR TITLE
Update default system prompt to include Slack user ID of bot

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,8 @@ def just_ack(ack: Ack):
 
 DEFAULT_SYSTEM_TEXT = """
 You are a bot in a slack chat room. You might receive messages from multiple people.
-Each message has the author id prepended, like this: "<@U1234> message text".
+Slack user IDs match the regex `<@U.*?>`.
+Your Slack user ID is <@{BOT_USER_ID}>.
 """
 SYSTEM_TEXT = os.environ.get("SYSTEM_TEXT", DEFAULT_SYSTEM_TEXT)
 
@@ -57,8 +58,10 @@ def start_convo(
             )
             return
 
+        # Replace placeholder for Slack user ID in the system prompt
+        new_system_text = SYSTEM_TEXT.replace("{BOT_USER_ID}", context.bot_user_id)
         messages = [
-            {"role": "system", "content": SYSTEM_TEXT},
+            {"role": "system", "content": new_system_text},
             {"role": "user", "content": format_openai_message_content(payload["text"])},
         ]
         wip_reply = post_wip_message(


### PR DESCRIPTION
Update the default system prompt and introduce a placeholder that can be replaced with the Slack user ID of the bot when the thread is first created. This can be used to tell the bot who it is on Slack, so it doesn't confuse `@ChatGPT initial prompt` with `@ChatGPT` saying `initial prompt`.

Example 1 with this PR:
Initial prompt: `Who is @ChatGPT`?
Example reply: `That is my Slack user ID! I am a bot designed to help with various tasks in this Slack chat room.`

Example 2 with this PR:
Initial prompt: `@ChatGPT What is your Slack user ID?`
Example reply: `My Slack user ID is @ChatGPT`

Fixes #12.
