### PR TITLE
Minor fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,7 +80,7 @@ def start_convo(
             client=client,
             wip_reply=wip_reply,
             context=context,
-            user_id=context.actor_user_id,
+            user_id=context.user_id,
             messages=messages,
             steam=steam,
             timeout_seconds=OPENAI_TIMEOUT_SECONDS,

--- a/internals.py
+++ b/internals.py
@@ -219,6 +219,7 @@ def format_assistant_reply(content: str) -> str:
         ("```\\s*[Cc][Pp][Pp]\n", "```\n"),
         ("```\\s*[Cc]sharp\n", "```\n"),
         ("```\\s*[Mm]atlab\n", "```\n"),
+        ("```\\s*[Ll]a[Tt]e[Xx]\n", "```\n"),
         ("```\\s*[Ss][Qq][Ll]\n", "```\n"),
         ("```\\s*[Pp][Hh][Pp]\n", "```\n"),
         ("```\\s*[Pp][Ee][Rr][Ll]\n", "```\n"),

--- a/internals.py
+++ b/internals.py
@@ -36,7 +36,7 @@ def start_receiving_openai_response(
     # Remove old user messages to make sure we have room for max_tokens
     # See also: https://platform.openai.com/docs/guides/chat/introduction
     # > total tokens must be below the model’s maximum limit (4096 tokens for gpt-3.5-turbo-0301)
-    while calculate_num_tokens(messages) >= 4096 - MAX_TOKENS:
+    while calculate_num_tokens(messages) >= 4096 - MAX_TOKENS - 10:
         removed = False
         for i, message in enumerate(messages):
             if message["role"] == "user":

--- a/internals_test.py
+++ b/internals_test.py
@@ -23,6 +23,14 @@ def test_format_assistant_reply():
         ("\n\n```csharp\nusing System;\n```", "```\nusing System;\n```"),
         ("\n\n```Matlab\ndisp('foo');\n```", "```\ndisp('foo');\n```"),
         ("\n\n```matlab\ndisp('foo');\n```", "```\ndisp('foo');\n```"),
+        (
+            "\n\n```LaTeX\n\\documentclass{article}\n```",
+            "```\n\\documentclass{article}\n```",
+        ),
+        (
+            "\n\n```latex\n\\documentclass{article}\n```",
+            "```\n\\documentclass{article}\n```",
+        ),
     ]:
         result = format_assistant_reply(content)
         assert result == expected

--- a/validate.sh
+++ b/validate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 pip install -r requirements.txt
 pip install black && black ./*.py
-pytest .
+pip install pytest && pytest .
 pip install "flake8==6.0.0" && flake8 ./*.py
 pip install "pytype==2023.03.02" boto3 && pytype ./*.py


### PR DESCRIPTION
Minor fixes:
- I couldn't find `actor_user_id` in slack-bolt 1.17.0rc2 required from 65cbd9be1928aa6e3f62a5575cf30314dcc7e0cb, so I replaced it with `user_id` to avoid a runtime error when creating a new Slack thread.
- Strip LaTeX syntax tags.
- Ensure pytest is installed.
- Add some tolerance for error in the token count to fix rare issue when the Slack thread was very close to the 4096 token limit, and either the count calculation was wrong or OpenAI was returning a few extra tokens.