### PR TITLE
Fix hung threads and missing text due to long replies, and other minor fixes

### DIFF
--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -271,7 +271,7 @@ def reply_if_necessary(
                 else ""
             )
             + "\n\n"
-            + f":warning: Failed to start a conversation with ChatGPT: {e}"
+            + f":warning: Failed to reply: {e}"
         )
         logger.exception(text, e)
         if wip_reply is not None:

--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -189,11 +189,10 @@ def reply_if_necessary(
         for idx, reply in enumerate(reply_messages):
             if idx not in indices_to_remove:
                 filtered_reply_messages.append(reply)
-        if len(filtered_reply_messages) == last_assistant_idx + 1:
+        if len(filtered_reply_messages) == 0:
             return
 
-        start_idx = last_assistant_idx + 1
-        for reply in filtered_reply_messages[start_idx:]:
+        for reply in filtered_reply_messages:
             messages.append(
                 {
                     "content": format_openai_message_content(reply.get("text")),

--- a/app/openai_ops.py
+++ b/app/openai_ops.py
@@ -36,14 +36,14 @@ def start_receiving_openai_response(
     messages: List[Dict[str, str]],
     user: str,
 ) -> Generator[OpenAIObject, Any, None]:
-    # Remove old user messages to make sure we have room for max_tokens
+    # Remove old messages to make sure we have room for max_tokens
     # See also: https://platform.openai.com/docs/guides/chat/introduction
     # > total tokens must be below the model’s maximum limit (4096 tokens for gpt-3.5-turbo-0301)
     # TODO: currently we don't pass gpt-4 to this calculation method
     while calculate_num_tokens(messages) >= 4096 - MAX_TOKENS - 10:
         removed = False
         for i, message in enumerate(messages):
-            if message["role"] == "user":
+            if message["role"] in ("user", "assistant"):
                 del messages[i]
                 removed = True
                 break

--- a/app/openai_ops.py
+++ b/app/openai_ops.py
@@ -40,7 +40,7 @@ def start_receiving_openai_response(
     # See also: https://platform.openai.com/docs/guides/chat/introduction
     # > total tokens must be below the model’s maximum limit (4096 tokens for gpt-3.5-turbo-0301)
     # TODO: currently we don't pass gpt-4 to this calculation method
-    while calculate_num_tokens(messages) >= 4096 - MAX_TOKENS - 10:
+    while calculate_num_tokens(messages) >= 4096 - MAX_TOKENS:
         removed = False
         for i, message in enumerate(messages):
             if message["role"] in ("user", "assistant"):

--- a/app/openai_ops.py
+++ b/app/openai_ops.py
@@ -195,6 +195,7 @@ def format_assistant_reply(content: str) -> str:
         ("```\\s*[Cc][Pp][Pp]\n", "```\n"),
         ("```\\s*[Cc]sharp\n", "```\n"),
         ("```\\s*[Mm]atlab\n", "```\n"),
+        ("```\\s*[Jj][Ss][Oo][Nn]\n", "```\n"),
         ("```\\s*[Ll]a[Tt]e[Xx]\n", "```\n"),
         ("```\\s*[Ss][Qq][Ll]\n", "```\n"),
         ("```\\s*[Pp][Hh][Pp]\n", "```\n"),

--- a/app/wip_message.py
+++ b/app/wip_message.py
@@ -11,13 +11,14 @@ def post_wip_message(
     messages: List[Dict[str, str]],
     user: str,
 ) -> SlackResponse:
+    system_messages = [msg for msg in messages if msg["role"] == "system"]
     return client.chat_postMessage(
         channel=channel,
         thread_ts=thread_ts,
         text=loading_text,
         metadata={
             "event_type": "chat-gpt-convo",
-            "event_payload": {"messages": messages, "user": user},
+            "event_payload": {"messages": system_messages, "user": user},
         },
     )
 
@@ -30,12 +31,13 @@ def update_wip_message(
     messages: List[Dict[str, str]],
     user: str,
 ) -> SlackResponse:
+    system_messages = [msg for msg in messages if msg["role"] == "system"]
     return client.chat_update(
         channel=channel,
         ts=ts,
         text=text,
         metadata={
             "event_type": "chat-gpt-convo",
-            "event_payload": {"messages": messages, "user": user},
+            "event_payload": {"messages": system_messages, "user": user},
         },
     )

--- a/tests/openai_ops_test.py
+++ b/tests/openai_ops_test.py
@@ -23,6 +23,8 @@ def test_format_assistant_reply():
         ("\n\n```csharp\nusing System;\n```", "```\nusing System;\n```"),
         ("\n\n```Matlab\ndisp('foo');\n```", "```\ndisp('foo');\n```"),
         ("\n\n```matlab\ndisp('foo');\n```", "```\ndisp('foo');\n```"),
+        ("\n\n```JSON\n{\n```", "```\n{\n```"),
+        ("\n\n```json\n{\n```", "```\n{\n```"),
         (
             "\n\n```LaTeX\n\\documentclass{article}\n```",
             "```\n\\documentclass{article}\n```",


### PR DESCRIPTION
This PR contains the following fixes/updates:
- Strip JSON syntax tags
- For threads that exceed 4096 tokens, remove old assistant message as well as user messages
- Use different warning message when error occurs when replying to a thread vs starting a new one
- Fix `metadata_too_large` warning from causing a thread to hang if the first bot reply in a thread is too long
- Fix missing text when asking the bot to continue a long response after a `msg_too_long` error

These last two issues are closely related, and occur due to trying to store the entire conversation so far in the metadata for each bot reply. When the metadata becomes too large, it is ignored when written to subsequent messages, and `reply_if_necessary` will read the later messages from the Slack text rather than the metadata. This approach works well in most cases, but there are two situations where it doesn't, and these happen when we run into Slack metadata or text length limitations before reaching the OpenAI output token limit.

If the first bot response in a thread exceeds the maximum metadata size (4000 bytes), the metadata will never be written to the thread and the bot will never reply in that thread again, since the `chat-gpt-convo` event type is never written.
Before this PR:
```
user: Write a 60-step tutorial on how to bake a cake.
ChatGPT: 1. blah
         2. blah
         ...
         42. blah
user: continue
no response from bot
```

The second issue is difficult to reliably reproduce, but occurs when asking the bot to continue a long output (more than about 3800 characters, but less than the metadata size limit of 4000 bytes) that triggers a `msg_too_long` error. In this case Slack truncates the message text. When asked to continue, the bot reply will appear to be missing some text, due to the metadata being read instead of the shorter message text displayed in the previous message.
Before this PR:
```
... other short messages in thread
user: Write a 60-step tutorial on how to bake a cake.
ChatGPT: 1. blah
         2. blah
         ...
         42. blah
user: continue
ChatGPT: 48. blah
         49. blah
         ...
         60. blah
```

The fix contained in this PR is simply to not store the user/assistant messages in the metadata, and always retrieve these from the Slack message text. The metadata now only contains the system message and the event type.

After this PR:
```
user: Write a 60-step tutorial on how to bake a cake.
ChatGPT: 1. blah
         2. blah
         ...
         42. blah
user: continue
ChatGPT: 43. blah
         ...
         60. blah
```