### PR TITLE
Better support for markdown formatted text

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ for mistakes and make suggestion to improve the language of the given text"
 export USE_SLACK_LANGUAGE=true
 # Optional: Adjust the app's logging level (default: DEBUG)
 export SLACK_APP_LOG_LEVEL=INFO
+# Optional: When the string is "true", translate between OpenAI markdown and Slack mrkdwn format (default: false)
+export TRANSLATE_MARKDOWN=true
 
 python -m venv .venv
 source .venv/bin/activate

--- a/app/env.py
+++ b/app/env.py
@@ -2,6 +2,7 @@ import os
 
 DEFAULT_SYSTEM_TEXT = """
 You are a bot in a slack chat room. You might receive messages from multiple people.
+Format bold text *like this*, italic text _like this_ and strikethrough text ~like this~.
 Slack user IDs match the regex `<@U.*?>`.
 Your Slack user ID is <@{bot_user_id}>.
 """
@@ -18,3 +19,5 @@ OPENAI_MODEL = os.environ.get("OPENAI_MODEL", DEFAULT_OPENAI_MODEL)
 USE_SLACK_LANGUAGE = os.environ.get("USE_SLACK_LANGUAGE", "true") == "true"
 
 SLACK_APP_LOG_LEVEL = os.environ.get("SLACK_APP_LOG_LEVEL", "DEBUG")
+
+TRANSLATE_MARKDOWN = os.environ.get("TRANSLATE_MARKDOWN", "false") == "true"

--- a/tests/openai_ops_test.py
+++ b/tests/openai_ops_test.py
@@ -1,4 +1,9 @@
-from app.openai_ops import format_assistant_reply, format_openai_message_content
+from app.openai_ops import (
+    markdown_to_slack,
+    slack_to_markdown,
+    format_assistant_reply,
+    format_openai_message_content,
+)
 
 
 def test_format_assistant_reply():
@@ -34,7 +39,7 @@ def test_format_assistant_reply():
             "```\n\\documentclass{article}\n```",
         ),
     ]:
-        result = format_assistant_reply(content)
+        result = format_assistant_reply(content, False)
         assert result == expected
 
 
@@ -56,5 +61,93 @@ int main(int argc, char *argv[])
 }""",
         ),
     ]:
-        result = format_openai_message_content(content)
+        result = format_openai_message_content(content, False)
+        assert result == expected
+
+
+def test_markdown_to_slack():
+    for content, expected in [
+        (
+            "Sentence with **bold text**, __bold text__, *italic text*, _italic text_ and ~~strikethrough text~~.",
+            "Sentence with *bold text*, *bold text*, _italic text_, _italic text_ and ~strikethrough text~.",
+        ),
+        (
+            "Sentence with ***bold and italic text***, **_bold and italic text_**, and _**bold and italic text**_.",
+            "Sentence with _*bold and italic text*_, *_bold and italic text_*, and _*bold and italic text*_.",
+        ),
+        (
+            "Code block ```**text**, __text__, *text*, _text_ and ~~text~~``` shouldn't be changed.",
+            "Code block ```**text**, __text__, *text*, _text_ and ~~text~~``` shouldn't be changed.",
+        ),
+        (
+            "```Some `**bold text** inside inline code` inside a code block``` shouldn't be changed.",
+            "```Some `**bold text** inside inline code` inside a code block``` shouldn't be changed.",
+        ),
+        (
+            "Inline code `**text**, __text__, *text*, _text_ and ~~text~~` shouldn't be changed.",
+            "Inline code `**text**, __text__, *text*, _text_ and ~~text~~` shouldn't be changed.",
+        ),
+        ("* bullets shouldn't\n* be changed", "* bullets shouldn't\n* be changed"),
+        (
+            "** not bold**, **not bold **, ** not bold **, ****, ** **, **  **, **   **",
+            "** not bold**, **not bold **, ** not bold **, ****, ** **, **  **, **   **",
+        ),
+        (
+            "__ not bold__, __not bold __, __ not bold __, ____, __ __, __  __, __   __",
+            "__ not bold__, __not bold __, __ not bold __, ____, __ __, __  __, __   __",
+        ),
+        (
+            "* not italic*, *not italic *, * not italic *, **, * *, *  *, *   *",
+            "* not italic*, *not italic *, * not italic *, **, * *, *  *, *   *",
+        ),
+        (
+            "_ not italic_, _not italic _, _ not italic _, __, _ _, _  _, _   _",
+            "_ not italic_, _not italic _, _ not italic _, __, _ _, _  _, _   _",
+        ),
+        (
+            "~~ not strikethrough~~, ~~not strikethrough ~~, ~~ not strikethrough ~~, ~~~~, ~~ ~~, ~~  ~~, ~~   ~~",
+            "~~ not strikethrough~~, ~~not strikethrough ~~, ~~ not strikethrough ~~, ~~~~, ~~ ~~, ~~  ~~, ~~   ~~",
+        ),
+    ]:
+        result = markdown_to_slack(content)
+        assert result == expected
+
+
+def test_slack_to_markdown():
+    for content, expected in [
+        (
+            "Sentence with *bold text*, _italic text_ and ~strikethrough text~.",
+            "Sentence with **bold text**, *italic text* and ~~strikethrough text~~.",
+        ),
+        (
+            "Sentence with _*bold and italic text*_ and *_bold and italic text_*.",
+            "Sentence with ***bold and italic text*** and ***bold and italic text***.",
+        ),
+        (
+            "Code block ```*text*, _text_ and ~text~``` shouldn't be changed.",
+            "Code block ```*text*, _text_ and ~text~``` shouldn't be changed.",
+        ),
+        (
+            "Inline code `*text*, _text_ and ~text~` shouldn't be changed.",
+            "Inline code `*text*, _text_ and ~text~` shouldn't be changed.",
+        ),
+        (
+            "```Some `*bold text* inside inline code` inside a code block``` shouldn't be changed.",
+            "```Some `*bold text* inside inline code` inside a code block``` shouldn't be changed.",
+        ),
+        ("* bullets shouldn't\n* be changed", "* bullets shouldn't\n* be changed"),
+        (
+            "* not bold*, *not bold *, * not bold *, **, * *, *  *, *   *",
+            "* not bold*, *not bold *, * not bold *, **, * *, *  *, *   *",
+        ),
+        (
+            "_ not italic_, _not italic _, _ not italic _, __, _ _, _  _, _   _",
+            "_ not italic_, _not italic _, _ not italic _, __, _ _, _  _, _   _",
+        ),
+        (
+            "~ not strikethrough~, ~not strikethrough ~, ~ not strikethrough ~, ~~, ~ ~, ~  ~, ~   ~",
+            "~ not strikethrough~, ~not strikethrough ~, ~ not strikethrough ~, ~~, ~ ~, ~  ~, ~   ~",
+        ),
+    ]:
+        result = slack_to_markdown(content)
         assert result == expected


### PR DESCRIPTION
A new feature for your consideration.

OpenAI will generate text that is typically formatted using markdown. This text does not display correctly in Slack due to the slightly different mrkdwn format it uses. In particular, this PR addresses bold, italic and strikethrough text and various combinations of these.

Once approach to deal with this is to include a system prompt with explicit instructions to use mrkdwn formatted text. This works most of the time, but the GPT models will sometimes ignore these instructions and generate markdown anyway.

This PR adds a default system prompt that includes instructions to format text using mrkdwn format and provide a new feature that can directly translate between markdown and mrkdwn formats with a new environment variable TRANSLATE_MARKDOWN.

When the new environment variable TRANSLATE_MARKDOWN is set to true:
- Any mrkdwn in the system prompt is translated to markdown (the prompt now reinforces using markdown format)
- Messages received from OpenAI that contain markdown formatting are converted to mrkdwn when they appear in Slack messages
- Slack messages are translated back into markdown format before being sent to OpenAI
- Care is taken not to modify any text within inline code or code blocks.

This ensures that as far as the OpenAI model is concerned, both it and the users appear to be consistently using markdown at all times. 

TRANSLATE_MARKDOWN is disabled by default if omitted from the exported environment variables as there are some caveats:
- There may be a performance overhead due to the complexity of the regular expressions involved.
- If very long output with code is truncated and is missing the closing triple backtick, there can be unintended format translation, e.g., `__init__` in Python can be incorrectly modified to `*init*`.

TRANSLATE_MARKDOWN=false is recommended for instances where the bot is doing a lot of code generation. The new system prompt should work most of the time.
TRANSLATE_MARKDOWN=true is recommended for instances where the bot is mostly doing natural language tasks.

Example before this PR:
<img width="421" alt="markdown_before_pr" src="https://user-images.githubusercontent.com/62312786/227704873-4f4115d3-cb25-40fd-9a47-ed5b37a3bc7b.png">

Example after this PR:
<img width="493" alt="markdown_after_pr" src="https://user-images.githubusercontent.com/62312786/227704877-d714849e-7f99-4bcf-af01-d435a8dcdee2.png">
