### PR TITLE
Better support multi-user conversations

### DIFF
--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from openai.error import Timeout
 from slack_bolt import App, Ack, BoltContext, BoltResponse
@@ -63,7 +64,7 @@ def start_convo(
 
         user_id = context.actor_user_id or context.user_id
         # Strip bot Slack user ID from initial message
-        msg_text = payload["text"].replace(f"<@{context.bot_user_id}>", "")
+        msg_text = re.sub(f"<@{context.bot_user_id}>\\s*", "", payload["text"])
         messages = [
             {"role": "system", "content": new_system_text},
             {

--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -61,13 +61,15 @@ def start_convo(
         if TRANSLATE_MARKDOWN:
             new_system_text = slack_to_markdown(new_system_text)
 
+        user_id = context.actor_user_id or context.user_id
+        # Strip bot Slack user ID from initial message
+        msg_text = payload["text"].replace(f"<@{context.bot_user_id}>", "")
         messages = [
             {"role": "system", "content": new_system_text},
             {
                 "role": "user",
-                "content": format_openai_message_content(
-                    payload["text"], TRANSLATE_MARKDOWN
-                ),
+                "content": f"<@{user_id}>: "
+                + format_openai_message_content(msg_text, TRANSLATE_MARKDOWN),
             },
         ]
         loading_text = translate(
@@ -91,7 +93,7 @@ def start_convo(
             client=client,
             wip_reply=wip_reply,
             context=context,
-            user_id=context.actor_user_id or context.user_id,
+            user_id=user_id,
             messages=messages,
             steam=steam,
             timeout_seconds=OPENAI_TIMEOUT_SECONDS,
@@ -201,15 +203,20 @@ def reply_if_necessary(
 
         filtered_reply_messages = []
         for idx, reply in enumerate(reply_messages):
+            # Strip bot Slack user ID from initial message
+            if idx == 0:
+                reply["text"] = reply["text"].replace(f"<@{context.bot_user_id}>", "")
             if idx not in indices_to_remove:
                 filtered_reply_messages.append(reply)
         if len(filtered_reply_messages) == 0:
             return
 
         for reply in filtered_reply_messages:
+            msg_user_id = reply.get("user")
             messages.append(
                 {
-                    "content": format_openai_message_content(
+                    "content": f"<@{msg_user_id}>: "
+                    + format_openai_message_content(
                         reply.get("text"), TRANSLATE_MARKDOWN
                     ),
                     "role": "user",

--- a/app/env.py
+++ b/app/env.py
@@ -5,6 +5,7 @@ You are a bot in a slack chat room. You might receive messages from multiple peo
 Format bold text *like this*, italic text _like this_ and strikethrough text ~like this~.
 Slack user IDs match the regex `<@U.*?>`.
 Your Slack user ID is <@{bot_user_id}>.
+Each message has the author's Slack user ID prepended, like the regex `^<@U.*?>: ` followed by the message text.
 """
 SYSTEM_TEXT = os.environ.get("OPENAI_SYSTEM_TEXT", DEFAULT_SYSTEM_TEXT)
 

--- a/app/openai_ops.py
+++ b/app/openai_ops.py
@@ -192,9 +192,12 @@ def calculate_num_tokens(
 
 # Format message from OpenAI to display in Slack
 def format_assistant_reply(content: str, translate_markdown: bool) -> str:
-    # Remove OpenAI syntax tags since Slack doesn't render them in a message
     for o, n in [
+        # Remove leading newlines
         ("^\n+", ""),
+        # Remove prepended Slack user ID
+        ("^<@U.*?>\\s?:\\s?", ""),
+        # Remove OpenAI syntax tags since Slack doesn't render them in a message
         ("```\\s*[Rr]ust\n", "```\n"),
         ("```\\s*[Rr]uby\n", "```\n"),
         ("```\\s*[Ss]cala\n", "```\n"),


### PR DESCRIPTION
This PR enables the bot to see all Slack user IDs participating in a conversation and better enable the bot to interact with multiple users. This also helps avoid the bot from getting confused about who said what in a conversation thread.
This is an implementation of the "better fix" suggested in the thread for issue #12 and a follow up to PR #14 (bot only knows its own Slack user ID).

This works by 
- Prepending the messages sent to OpenAI with the Slack user IDs of each author
- Stripping any author prefix from the reply from OpenAI before displaying in a Slack message
- Stripping the bot Slack user ID from the first message in the thread
- Reintroducing a system prompt to explain the expected message format

This mechanism can be seen in action in the conversation below:
![user_ids](https://user-images.githubusercontent.com/62312786/228380495-42cbfed4-37cf-4bc2-ae07-3798285ac4c2.png)
