### PR TITLE
Bugfixes and better GPT-4 support

### DIFF
--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -126,7 +126,7 @@ def respond_to_app_mention(
             messages,
             num_context_tokens,
             max_context_tokens,
-        ) = messages_within_context_window(messages)
+        ) = messages_within_context_window(messages, model=context["OPENAI_MODEL"])
         num_messages = len([msg for msg in messages if msg.get("role") != "system"])
         if num_messages == 0:
             update_wip_message(
@@ -339,7 +339,7 @@ def respond_to_new_message(
             messages,
             num_context_tokens,
             max_context_tokens,
-        ) = messages_within_context_window(messages)
+        ) = messages_within_context_window(messages, model=context["OPENAI_MODEL"])
         num_messages = len([msg for msg in messages if msg.get("role") != "system"])
         if num_messages == 0:
             update_wip_message(

--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -266,10 +266,8 @@ def respond_to_new_message(
 
         if is_no_mention_required is False:
             return
-        if is_in_dm_with_bot is False and last_assistant_idx == -1:
-            return
 
-        if is_in_dm_with_bot is True:
+        if is_in_dm_with_bot is True or last_assistant_idx == -1:
             # To know whether this app needs to start a new convo
             if not next(filter(lambda msg: msg["role"] == "system", messages), None):
                 # Replace placeholder for Slack user ID in the system prompt

--- a/app/markdown.py
+++ b/app/markdown.py
@@ -5,7 +5,7 @@ import re
 # See also: https://api.slack.com/reference/surfaces/formatting#basics
 def slack_to_markdown(content: str) -> str:
     # Split the input string into parts based on code blocks and inline code
-    parts = re.split(r"(```.+?```|`[^`\n]+?`)", content)
+    parts = re.split(r"(?s)(```.+?```|`[^`\n]+?`)", content)
 
     # Apply the bold, italic, and strikethrough formatting to text not within code
     result = ""
@@ -27,7 +27,7 @@ def slack_to_markdown(content: str) -> str:
 # See also: https://api.slack.com/reference/surfaces/formatting#basics
 def markdown_to_slack(content: str) -> str:
     # Split the input string into parts based on code blocks and inline code
-    parts = re.split(r"(```.+?```|`[^`\n]+?`)", content)
+    parts = re.split(r"(?s)(```.+?```|`[^`\n]+?`)", content)
 
     # Apply the bold, italic, and strikethrough formatting to text not within code
     result = ""

--- a/app/openai_ops.py
+++ b/app/openai_ops.py
@@ -219,8 +219,8 @@ def format_assistant_reply(content: str, translate_markdown: bool) -> str:
         ("```\\s*[Ss][Qq][Ll]\n", "```\n"),
         ("```\\s*[Pp][Hh][Pp]\n", "```\n"),
         ("```\\s*[Pp][Ee][Rr][Ll]\n", "```\n"),
-        ("```\\s*[Jj]ava[Ss]cript", "```\n"),
-        ("```\\s*[Ty]ype[Ss]cript", "```\n"),
+        ("```\\s*[Jj]ava[Ss]cript\n", "```\n"),
+        ("```\\s*[Ty]ype[Ss]cript\n", "```\n"),
         ("```\\s*[Pp]ython\n", "```\n"),
     ]:
         content = re.sub(o, n, content)

--- a/app/openai_ops.py
+++ b/app/openai_ops.py
@@ -210,7 +210,7 @@ def format_assistant_reply(content: str, translate_markdown: bool) -> str:
         ("```\\s*[Cc][+][+]\n", "```\n"),
         ("```\\s*[Cc][Pp][Pp]\n", "```\n"),
         ("```\\s*[Cc]sharp\n", "```\n"),
-        ("```\\s*[Mm]atlab\n", "```\n"),
+        ("```\\s*[Mm][Aa][Tt][Ll][Aa][Bb]\n", "```\n"),
         ("```\\s*[Jj][Ss][Oo][Nn]\n", "```\n"),
         ("```\\s*[Ll]a[Tt]e[Xx]\n", "```\n"),
         ("```\\s*bash\n", "```\n"),

--- a/tests/markdown_test.py
+++ b/tests/markdown_test.py
@@ -47,6 +47,22 @@ def test_markdown_to_slack():
             "~~ not strikethrough~~, ~~not strikethrough ~~, ~~ not strikethrough ~~, ~~~~, ~~ ~~, ~~  ~~, ~~   ~~",
             "~~ not strikethrough~~, ~~not strikethrough ~~, ~~ not strikethrough ~~, ~~~~, ~~ ~~, ~~  ~~, ~~   ~~",
         ),
+        (
+            """The following multiline code block shouldn't be translated:
+```
+if 4*q + r - t < n*t:
+    q, r, t, k, n, l = 10*q, 10*(r-n*t), t, k, (10*(3*q+r))//t - 10*n, l
+else:
+    q, r, t, k, n, l = q*l, (2*q+r)*l, t*l, k+1, (q*(7*k+2)+r*l)//(t*l), l+2
+```""",
+            """The following multiline code block shouldn't be translated:
+```
+if 4*q + r - t < n*t:
+    q, r, t, k, n, l = 10*q, 10*(r-n*t), t, k, (10*(3*q+r))//t - 10*n, l
+else:
+    q, r, t, k, n, l = q*l, (2*q+r)*l, t*l, k+1, (q*(7*k+2)+r*l)//(t*l), l+2
+```""",
+        ),
     ]:
         result = markdown_to_slack(content)
         assert result == expected
@@ -86,6 +102,22 @@ def test_slack_to_markdown():
         (
             "~ not strikethrough~, ~not strikethrough ~, ~ not strikethrough ~, ~~, ~ ~, ~  ~, ~   ~",
             "~ not strikethrough~, ~not strikethrough ~, ~ not strikethrough ~, ~~, ~ ~, ~  ~, ~   ~",
+        ),
+        (
+            """The following multiline code block shouldn't be translated:
+```
+if 4*q + r - t < n*t:
+    q, r, t, k, n, l = 10*q, 10*(r-n*t), t, k, (10*(3*q+r))//t - 10*n, l
+else:
+    q, r, t, k, n, l = q*l, (2*q+r)*l, t*l, k+1, (q*(7*k+2)+r*l)//(t*l), l+2
+```""",
+            """The following multiline code block shouldn't be translated:
+```
+if 4*q + r - t < n*t:
+    q, r, t, k, n, l = 10*q, 10*(r-n*t), t, k, (10*(3*q+r))//t - 10*n, l
+else:
+    q, r, t, k, n, l = q*l, (2*q+r)*l, t*l, k+1, (q*(7*k+2)+r*l)//(t*l), l+2
+```""",
         ),
     ]:
         result = slack_to_markdown(content)


### PR DESCRIPTION
This PR includes several bugfixes and better GPT-4 support:
* Fix issue where if all the bot posted messages in a thread are deleted (e.g., by an admin), the bot would no longer post in that thread on the next prompt.
* Fix syntax tags for Matlab, JS and TS.
* Fix bug with unexpected markdown translation within multiline code blocks and add unit tests.
* Fix bug where if the previous message is too large (e.g., 4096 - 1024 = 3072 tokens for `gpt-3.5-turbo`), the bot would try to reply to an empty prompt since no recent messages fit within the context window. A warning message is now printed to the user indicating that the previous message was too large, along with the number of tokens.
* Update token calculation method and context window length to handle current versions of `gpt-3.5-turbo`, `gpt-4` and `gpt-4-32k`. This also follows up #11.