### PR TITLE
Avoid timing out when bot is still writing

### DIFF
--- a/app/openai_ops.py
+++ b/app/openai_ops.py
@@ -107,8 +107,9 @@ def consume_openai_stream_to_write_reply(
     threads = []
     try:
         loading_character = " ... :writing_hand:"
+        last_chunk_at = time.time()
         for chunk in stream:
-            spent_seconds = time.time() - start_time
+            spent_seconds = time.time() - last_chunk_at
             if timeout_seconds < spent_seconds:
                 raise Timeout()
             item = chunk.choices[0]
@@ -116,6 +117,7 @@ def consume_openai_stream_to_write_reply(
                 break
             delta = item.get("delta")
             if delta.get("content") is not None:
+                last_chunk_at = time.time()
                 word_count += 1
                 assistant_reply["content"] += delta.get("content")
                 if word_count >= 20:


### PR DESCRIPTION
There seems to be a bug for the timeout logic, the timeout doesn't reset when new data chunk are received.