### PR TITLE
Fix IndexError from Azure OpenAI API version 2023-06-01-preview

### DIFF
--- a/app/openai_ops.py
+++ b/app/openai_ops.py
@@ -125,8 +125,8 @@ def consume_openai_stream_to_write_reply(
             spent_seconds = time.time() - start_time
             if timeout_seconds < spent_seconds:
                 raise Timeout()
-            # Some Azure OpenAI API versions return an empty choices in the first chunk
-            if context["OPENAI_API_TYPE"] == "azure" and not chunk.choices:
+            # Some versions of the Azure OpenAI API return an empty choices array in the first chunk
+            if context.get("OPENAI_API_TYPE") == "azure" and not chunk.choices:
                 continue
             item = chunk.choices[0]
             if item.get("finish_reason") is not None:

--- a/app/openai_ops.py
+++ b/app/openai_ops.py
@@ -125,6 +125,9 @@ def consume_openai_stream_to_write_reply(
             spent_seconds = time.time() - start_time
             if timeout_seconds < spent_seconds:
                 raise Timeout()
+            # Some Azure OpenAI API versions return an empty choices in the first chunk
+            if context["OPENAI_API_TYPE"] == "azure" and not chunk.choices:
+                continue
             item = chunk.choices[0]
             if item.get("finish_reason") is not None:
                 break


### PR DESCRIPTION
From Azure OpenAI API version `2023-06-01-preview` onwards, the `choices` in the first chunk become empty (related issue: [Azure/azure-sdk-for-go#21086](https://github.com/Azure/azure-sdk-for-go/issues/21086)).

As a result, the following error occurred in those versions.
```
Traceback (most recent call last):
  File "/app/app/bolt_listeners.py", line 390, in respond_to_new_message
    consume_openai_stream_to_write_reply(
  File "/app/app/openai_ops.py", line 128, in consume_openai_stream_to_write_reply
    item = chunk.choices[0]
           ~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

Here is an example of such a chunk.
```
{
  "id": "",
  "object": "",
  "created": 0,
  "model": "",
  "prompt_annotations": [
    {
      "prompt_index": 0,
      "content_filter_results": {
        "hate": {
          "filtered": false,
          "severity": "safe"
        },
        "self_harm": {
          "filtered": false,
          "severity": "safe"
        },
        "sexual": {
          "filtered": false,
          "severity": "safe"
        },
        "violence": {
          "filtered": false,
          "severity": "safe"
        }
      }
    }
  ],
  "choices": [],
  "usage": null
}
```