### PR TITLE
Update token counting and strip additional syntax tags

### DIFF
--- a/app/openai_ops.py
+++ b/app/openai_ops.py
@@ -296,6 +296,8 @@ def format_assistant_reply(content: str, translate_markdown: bool) -> str:
         ("```\\s*[Mm][Aa][Tt][Ll][Aa][Bb]\n", "```\n"),
         ("```\\s*[Jj][Ss][Oo][Nn]\n", "```\n"),
         ("```\\s*[Ll]a[Tt]e[Xx]\n", "```\n"),
+        ("```\\s*[Ll][Uu][Aa]\n", "```\n"),
+        ("```\\s*[Cc][Mm][Aa][Kk][Ee]\n", "```\n"),
         ("```\\s*bash\n", "```\n"),
         ("```\\s*zsh\n", "```\n"),
         ("```\\s*sh\n", "```\n"),

--- a/tests/openai_ops_test.py
+++ b/tests/openai_ops_test.py
@@ -36,6 +36,11 @@ def test_format_assistant_reply():
             "\n\n```latex\n\\documentclass{article}\n```",
             "```\n\\documentclass{article}\n```",
         ),
+        ("\n\n```lua\nx = 1\n```", "```\nx = 1\n```"),
+        (
+            "\n\n```cmake\ncmake_minimum_required(VERSION 3.24)\n```",
+            "```\ncmake_minimum_required(VERSION 3.24)\n```",
+        ),
         ("\n\n```bash\n#!/bin/bash\n```", "```\n#!/bin/bash\n```"),
         ("\n\n```zsh\n#!/bin/zsh\n```", "```\n#!/bin/zsh\n```"),
         ("\n\n```sh\n#!/bin/sh\n```", "```\n#!/bin/sh\n```"),


### PR DESCRIPTION
This PR contains two changes:
- Update token counting to match current OpenAI documentation. At the time the 0613 models were released, the documentation for token counting had not been updated and it was assumed that the new models counted tokens in the message structure the same way as the previous model versions. In particular, there was a subtle difference between `gpt-3.5-turbo-0301` and `gpt-3.5-turbo-0613` that has now been corrected.
- Strip syntax tags for lua and cmake code and add unit tests.