### PR TITLE
Add a new feature to summarize a thread

### DIFF
--- a/app/i18n.py
+++ b/app/i18n.py
@@ -47,18 +47,18 @@ def translate(*, openai_api_key: str, context: BoltContext, text: str) -> str:
             {
                 "role": "system",
                 "content": "You're the AI model that primarily focuses on the quality of language translation. "
-                "You must not change the meaning of sentences when translating them into a different language. "
-                "You must provide direct translation result as much as possible. "
-                "When the given text is a single verb/noun, its translated text must be a norm/verb form too. "
+                "You always respond with the only the translated text in a format suitable for Slack user interface. "
                 "Slack's emoji (e.g., :hourglass_flowing_sand:) and mention parts must be kept as-is. "
-                "Your response must not include any additional notes in English. "
-                "Your response must omit English version / pronunciation guide for the result. ",
+                "You don't change the meaning of sentences when translating them into a different language. "
+                "When the given text is a single verb/noun, its translated text must be a norm/verb form too. ",
             },
             {
                 "role": "user",
-                "content": f"Can you translate {text} into {lang} in a professional tone? "
-                "Please respond with the only the translated text in a format suitable for Slack user interface. "
-                "No need to append any English notes and guides.",
+                "content": f"Can you translate the following text into {lang} in a professional tone? "
+                "Your response must omit any English version / pronunciation guide for the result. "
+                "Again, no need to append any English notes and guides about the result. "
+                "Just return the translation result. "
+                f"Here is the original sentence you need to translate:\n{text}",
             },
         ],
         top_p=1,

--- a/main_prod.py
+++ b/main_prod.py
@@ -249,8 +249,12 @@ def handler(event, context_):
                                     "value": "gpt-3.5-turbo",
                                 },
                                 {
-                                    "text": {"type": "plain_text", "text": "GPT-4"},
+                                    "text": {"type": "plain_text", "text": "GPT-4 8K"},
                                     "value": "gpt-4",
+                                },
+                                {
+                                    "text": {"type": "plain_text", "text": "GPT-4 32K"},
+                                    "value": "gpt-4-32k",
                                 },
                             ],
                             "initial_option": {

--- a/manifest-dev.yml
+++ b/manifest-dev.yml
@@ -8,9 +8,15 @@ features:
   bot_user:
     display_name: ChatGPT Bot (dev)
     always_online: true
+  shortcuts:
+    - name: Summarize this thread
+      type: message
+      callback_id: summarize-thread
+      description: Summarize the discussion in a thread
 oauth_config:
   scopes:
     bot:
+      - commands
       - app_mentions:read
       - channels:history
       - groups:history

--- a/manifest-prod.yml
+++ b/manifest-prod.yml
@@ -10,11 +10,17 @@ features:
   bot_user:
     display_name: ChatGPT Bot
     always_online: true
+  shortcuts:
+    - name: Summarize this thread
+      type: message
+      callback_id: summarize-thread
+      description: Summarize the discussion in a thread
 oauth_config:
   redirect_urls:
     - https://TODO.amazonaws.com/slack/oauth_redirect
   scopes:
     bot:
+      - commands
       - app_mentions:read
       - channels:history
       - groups:history


### PR DESCRIPTION
This pull request introduces an experimental feature that allows users to summarize a thread via a message shortcut. While there's room for improvement, particularly for long threads, the aim is to quickly roll out this feature to gather user feedback.

<img width="500" alt="Screenshot 2023-08-25 at 18 27 51" src="https://github.com/seratch/ChatGPT-in-Slack/assets/19658/bb8e326f-67ff-4e6d-aa2a-55cc1cf67382">
<img width="500" alt="Screenshot 2023-08-25 at 18 27 57" src="https://github.com/seratch/ChatGPT-in-Slack/assets/19658/67b41df0-6040-4b68-bf17-238c809ba44c">
<img width="500" alt="Screenshot 2023-08-25 at 18 28 13" src="https://github.com/seratch/ChatGPT-in-Slack/assets/19658/d0774b1e-1bb2-49e7-88bf-98c066514dcc">
