### PR TITLE
Add optional callback execution after function call

### DIFF
--- a/app/openai_ops.py
+++ b/app/openai_ops.py
@@ -233,6 +233,17 @@ def consume_openai_stream_to_write_reply(
                 "content": function_response,
             }
             messages.append(function_message)
+            function_called_callback = getattr(
+                function_call_module, f"{function_call['name']}_called", None
+            )
+            if function_called_callback is not None:
+                function_called_callback(
+                    function_response,
+                    client=client,
+                    wip_reply=wip_reply,
+                    context=context,
+                    messages=messages,
+                )
             messages_within_context_window(messages, context=context)
             sub_stream = start_receiving_openai_response(
                 openai_api_key=context.get("OPENAI_API_KEY"),

--- a/tests/function_call_example.py
+++ b/tests/function_call_example.py
@@ -29,3 +29,27 @@ functions = [
         },
     }
 ]
+
+
+def before_get_current_weather(*, messages):
+    print("before_get_current_weather called")
+
+
+def after_get_current_weather(*, function_response, messages):
+    print("after_get_current_weather called")
+
+
+function_callbacks = [
+    {
+        "function_name": "get_current_weather",
+        "callback_type": "before",
+        "callback_function_name": "before_get_current_weather",
+        # parameters: messages
+    },
+    {
+        "function_name": "get_current_weather",
+        "callback_type": "after",
+        "callback_function_name": "after_get_current_weather",
+        # parameters: function_response, messages
+    },
+]


### PR DESCRIPTION
This PR introduces the concept of optional callbacks, named `{original_function_name}_called`, executed directly after a corresponding function call.

I envisage the following two use cases:
1. **File Upload**: Pairing a `create_image` function with a `create_image_called` callback, we could handle the task of uploading the generated image to Slack.
2. **Retrieval-augmented Generation (RAG)**: If we pair a `search_faq` function with a `search_faq_called` callback, we could incorporate the search results into the user prompt.

I would appreciate your review and feedback on this implementation. Thank you for all your efforts in making this wonderful software available.