### PR TITLE
Fix the issue of no reply in a threaded mentioned message

### DIFF
--- a/app/slack_ops.py
+++ b/app/slack_ops.py
@@ -31,7 +31,7 @@ def find_parent_message(
 
 def is_no_mention_thread(context: BoltContext, parent_message: dict) -> bool:
     parent_message_text = parent_message.get("text", "")
-    return f"<@{context.bot_user_id}>" in parent_message_text
+    return f"<@{context.bot_user_id}>" not in parent_message_text
 
 
 def build_thread_replies_as_combined_text(


### PR DESCRIPTION
Dear reviewer

## Issue Summary
This PR is to fix an issue that the bot ignore following mentioned messages in a threaded conversation
The opened issue is #70, which this PR is targeted.

## Fix details
The `is_no_mention_thread` method defined in `slack_ops.py` returns the negated value than the correct one. This cause the app deems the message in a thread as a not mentioned one and ignore it. So a negate operation was added to fix it.

Would you please kindly review it?

Thanks.