### PR TITLE
Restrict bot usage to specific channels or users

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ export TRANSLATE_MARKDOWN=true
 export REDACTION_ENABLED=true
 # Optional: When the string is "true", this app shares image files with OpenAI (default: false)
 export IMAGE_FILE_ACCESS_ENABLED=true
+# Optional: Specify allowed channels for bot usage (comma-separated list of channel IDs)
+export ALLOWED_CHANNELS=C12345678,C23456789
+# Optional: Specify allowed users for bot usage (comma-separated list of user IDs)
+export ALLOWED_USERS=U12345678,U23456789
 
 # To use Azure OpenAI, set the following optional environment variables according to your environment
 # default: None

--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -90,6 +90,14 @@ def just_ack(ack: Ack):
 # Chat with the bot
 #
 
+def is_bot_allowed(channel_id: str, user_id: str) -> bool:
+    allowed_channels = os.environ.get("ALLOWED_CHANNELS", "").split(",")
+    allowed_users = os.environ.get("ALLOWED_USERS", "").split(",")
+    if (allowed_channels and channel_id not in allowed_channels) or (
+        allowed_users and user_id not in allowed_users
+    ):
+        return False
+    return True
 
 def respond_to_app_mention(
     context: BoltContext,
@@ -97,6 +105,9 @@ def respond_to_app_mention(
     client: WebClient,
     logger: logging.Logger,
 ):
+    if not is_bot_allowed(payload.get("channel_id"), payload.get("user_id")):
+        return
+
     thread_ts = payload.get("thread_ts")
     if thread_ts is not None:
         parent_message = find_parent_message(client, context.channel_id, thread_ts)
@@ -280,6 +291,9 @@ def respond_to_new_message(
     client: WebClient,
     logger: logging.Logger,
 ):
+    if not is_bot_allowed(payload.get("channel_id"), payload.get("user_id")):
+        return
+
     if payload.get("bot_id") is not None and payload.get("bot_id") != context.bot_id:
         # Skip a new message by a different app
         return

--- a/main.py
+++ b/main.py
@@ -75,5 +75,19 @@ if __name__ == "__main__":
         context["OPENAI_FUNCTION_CALL_MODULE_NAME"] = OPENAI_FUNCTION_CALL_MODULE_NAME
         next_()
 
+    @app.middleware
+    def check_access_control(context: BoltContext, payload: dict, next_):
+        allowed_channels = os.environ.get("ALLOWED_CHANNELS", "").split(",")
+        allowed_users = os.environ.get("ALLOWED_USERS", "").split(",")
+        channel_id = payload.get("channel_id")
+        user_id = payload.get("user_id")
+
+        if (allowed_channels and channel_id not in allowed_channels) or (
+            allowed_users and user_id not in allowed_users
+        ):
+            return
+
+        next_()
+
     handler = SocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])
     handler.start()

--- a/main_prod.py
+++ b/main_prod.py
@@ -182,6 +182,20 @@ def handler(event, context_):
         context["OPENAI_FUNCTION_CALL_MODULE_NAME"] = OPENAI_FUNCTION_CALL_MODULE_NAME
         next_()
 
+    @app.middleware
+    def check_access_control(context: BoltContext, payload: dict, next_):
+        allowed_channels = os.environ.get("ALLOWED_CHANNELS", "").split(",")
+        allowed_users = os.environ.get("ALLOWED_USERS", "").split(",")
+        channel_id = payload.get("channel_id")
+        user_id = payload.get("user_id")
+
+        if (allowed_channels and channel_id not in allowed_channels) or (
+            allowed_users and user_id not in allowed_users
+        ):
+            return
+
+        next_()
+
     #
     # Home tab rendering
     #


### PR DESCRIPTION
Related to #32

Add access control feature to restrict bot usage to specific channels or users.

* **Environment Variables**: Add `ALLOWED_CHANNELS` and `ALLOWED_USERS` environment variables in `main.py` and `main_prod.py` to specify allowed channels and users.
* **Middleware**: Update middleware in `main.py` and `main_prod.py` to check if the bot is allowed in the channel or by the user.
* **Access Control Function**: Add `is_bot_allowed` function in `app/bolt_listeners.py` to check if the bot is allowed to respond based on the specified channels and users.
* **Event Handlers**: Update `respond_to_app_mention` and `respond_to_new_message` in `app/bolt_listeners.py` to use `is_bot_allowed` function.
* **Documentation**: Update `README.md` to include instructions on how to configure the `ALLOWED_CHANNELS` and `ALLOWED_USERS` environment variables.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/seratch/ChatGPT-in-Slack/issues/32?shareId=91bedb24-e229-4dae-96e4-85ee3b146a00).