### PR TITLE
support gpt-4o-mini-2024-07-18 model

### DIFF
--- a/app/openai_constants.py
+++ b/app/openai_constants.py
@@ -19,6 +19,8 @@ GPT_4_32K_0314_MODEL = "gpt-4-32k-0314"
 GPT_4_32K_0613_MODEL = "gpt-4-32k-0613"
 GPT_4O_MODEL = "gpt-4o"
 GPT_4O_2024_05_13_MODEL = "gpt-4o-2024-05-13"
+GPT_4O_MINI_MODEL = "gpt-4o-mini"
+GPT_4O_MINI_2024_07_18_MODEL = "gpt-4o-mini-2024-07-18"
 
 # Tuple: (tokens_per_message, tokens_per_name)
 MODEL_TOKENS = {
@@ -42,6 +44,8 @@ MODEL_TOKENS = {
     GPT_4_TURBO_2024_04_09_MODEL: (3, 1),
     # GPT-4o
     GPT_4O_2024_05_13_MODEL: (3, 1),
+    # GPT-4o mini
+    GPT_4O_MINI_2024_07_18_MODEL: (3, 1),
 }
 
 # Note that these fallbacks may change over time.
@@ -52,4 +56,5 @@ MODEL_FALLBACKS = {
     GPT_4_TURBO_MODEL: GPT_4_TURBO_2024_04_09_MODEL,
     GPT_4_32K_MODEL: GPT_4_32K_0613_MODEL,
     GPT_4O_MODEL: GPT_4O_2024_05_13_MODEL,
+    GPT_4O_MINI_MODEL: GPT_4O_MINI_2024_07_18_MODEL,
 }

--- a/app/openai_ops.py
+++ b/app/openai_ops.py
@@ -37,6 +37,8 @@ from app.openai_constants import (
     GPT_4_32K_0613_MODEL,
     GPT_4O_MODEL,
     GPT_4O_2024_05_13_MODEL,
+    GPT_4O_MINI_MODEL,
+    GPT_4O_MINI_2024_07_18_MODEL,
     MODEL_TOKENS,
     MODEL_FALLBACKS,
 )
@@ -342,6 +344,9 @@ def context_length(
     elif model == GPT_4O_MODEL:
         # Note that GPT_4O_MODEL may change over time. Return context length assuming GPT_4O_2024_05_13_MODEL.
         return context_length(model=GPT_4O_2024_05_13_MODEL)
+    elif model == GPT_4O_MINI_MODEL:
+        # Note that GPT_4O_MINI_MODEL may change over time. Return context length assuming GPT_4O_MINI_2024_07_18_MODEL.
+        return context_length(model=GPT_4O_MINI_2024_07_18_MODEL)
     elif model == GPT_3_5_TURBO_0301_MODEL or model == GPT_3_5_TURBO_0613_MODEL:
         return 4096
     elif (
@@ -359,6 +364,7 @@ def context_length(
         or model == GPT_4_0125_PREVIEW_MODEL
         or model == GPT_4_TURBO_2024_04_09_MODEL
         or model == GPT_4O_2024_05_13_MODEL
+        or model == GPT_4O_MINI_2024_07_18_MODEL
     ):
         return 128000
     else:

--- a/app/slack_ui.py
+++ b/app/slack_ui.py
@@ -8,6 +8,7 @@ from app.openai_constants import (
     GPT_4_MODEL,
     GPT_4_32K_MODEL,
     GPT_4O_MODEL,
+    GPT_4O_MINI_MODEL,
 )
 from app.slack_constants import TIMEOUT_ERROR_MESSAGE
 from app.slack_ops import extract_state_value
@@ -359,6 +360,10 @@ def build_configure_modal(context: BoltContext) -> dict:
         {
             "text": {"type": "plain_text", "text": "GPT-4o"},
             "value": GPT_4O_MODEL,
+        },
+        {
+            "text": {"type": "plain_text", "text": "GPT-4o-mini"},
+            "value": GPT_4O_MINI_MODEL,
         },
     ]
     return {


### PR DESCRIPTION
This PR is for supporting the following latest models:

gpt-4o-mini-2024-07-18
gpt-4o-mini (currently points to gpt-4o-mini-2024-07-18) Based on my testing, it appears we can continue to use the same token count calculation method as the previous models.