### PR TITLE
Added Slack Translate Shortcut

### DIFF
--- a/app/slack_constants.py
+++ b/app/slack_constants.py
@@ -8,3 +8,4 @@ TIMEOUT_ERROR_MESSAGE = (
 )
 
 DEFAULT_LOADING_TEXT = ":hourglass_flowing_sand: Wait a second, please ..."
+MAX_MESSAGE_LENGTH = 3000

--- a/manifest-dev.yml
+++ b/manifest-dev.yml
@@ -13,6 +13,10 @@ features:
       type: message
       callback_id: summarize-thread
       description: Summarize the discussion in a thread
+    - name: Translate message
+      type: message
+      callback_id: translate-message
+      description: Translate the selected messages to your Slack language
 oauth_config:
   scopes:
     bot:

--- a/manifest-prod.yml
+++ b/manifest-prod.yml
@@ -15,6 +15,10 @@ features:
       type: message
       callback_id: summarize-thread
       description: Summarize the discussion in a thread
+    - name: Translate message
+      type: message
+      callback_id: translate-message
+      description: Translate the selected messages to your Slack language
 oauth_config:
   redirect_urls:
     - https://TODO.amazonaws.com/slack/oauth_redirect


### PR DESCRIPTION
### Description
This PR introduces a new Slack shortcut for translating messages. Users can now select messages and translate them into their Slack language preference using OpenAI’s translation capabilities.

### Changes
- Implemented translation modals (build_translation_modal, build_translation_wip_modal, build_translation_result_modal).
- Registered translate-message shortcut and modal handlers.
- Updated manifest-dev.yml and manifest-prod.yml to include the new feature.
