### PR TITLE
Update Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11.4-slim-buster as builder
+FROM python:3.11.11-slim-bookworm as builder
 COPY requirements.txt /build/
 WORKDIR /build/
 RUN pip install -U pip && pip install -r requirements.txt
 
-FROM python:3.11.4-slim-buster as app
+FROM python:3.11.11-slim-bookworm as app
 WORKDIR /app/
 COPY *.py /app/
 RUN mkdir /app/app/


### PR DESCRIPTION
Debian 10 (buster) is in an end-of-support state (see: https://www.debian.org/releases/). This updates the build & app base images to the newest version.