### PR TITLE
Refine Chinese locale mapping for zh-CN and zh-TW

### DIFF
--- a/app/i18n.py
+++ b/app/i18n.py
@@ -18,8 +18,8 @@ _locale_to_lang = {
     "pt-BR": "Portuguese",
     "ru-RU": "Russian",
     "ja-JP": "Japanese",
-    "zh-CN": "Chinese",
-    "zh-TW": "Chinese",
+    "zh-CN": "Simplified Chinese",
+    "zh-TW": "Traditional Chinese",
     "ko-KR": "Korean",
 }
 


### PR DESCRIPTION
Update `_locale_to_lang` to map `zh-CN` to Simplified Chinese and `zh-TW` to Traditional Chinese. This ensures the translation API receives the correct variant, improving accuracy for Chinese locales.