### PR TITLE
Add Python 3.12 and 3.13 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Expand the GitHub Actions matrix to include the latest CPython releases; it keeps coverage for 3.9–3.11, validates on 3.12 and 3.13 to catch version-specific issues early and signal official support, and prepares us for 3.14 which is nearing release.