### PR TITLE
Improve markdown_to_slack spacing around East Asian text and code

### DIFF
--- a/tests/markdown_conversion_test.py
+++ b/tests/markdown_conversion_test.py
@@ -122,3 +122,33 @@ else:
     ]:
         result = slack_to_markdown(content)
         assert result == expected
+
+
+def test_markdown_to_slack_eaw_spacing():
+    # Ensure spacing is inserted around Slack markers next to East Asian wide
+    # characters and fullwidth punctuation, and not inserted for halfwidth.
+    for content, expected in [
+        ("這是**粗體**文字。", "這是 *粗體* 文字。"),
+        ("中文_斜體_中文", "中文 _斜體_ 中文"),
+        ("中文~~刪除~~中文，標點", "中文 ~刪除~ 中文，標點"),
+        ("括號：「**強調**」", "括號：「 *強調* 」"),
+        ("ひらがな**強調**ひらがな", "ひらがな *強調* ひらがな"),
+        ("한글**강조**한글", "한글 *강조* 한글"),
+        ("ㄅㄆㄇ**強調**ㄈㄉㄊ", "ㄅㄆㄇ *強調* ㄈㄉㄊ"),
+        # Halfwidth Katakana neighbors should not add spaces
+        ("ｶﾀｶﾅ**強調**ｶﾀｶﾅ", "ｶﾀｶﾅ*強調*ｶﾀｶﾅ"),
+        # Code spans should not be changed
+        ("Inline code `**粗體**` test", "Inline code `**粗體**` test"),
+    ]:
+        result = markdown_to_slack(content)
+        assert result == expected
+
+
+def test_markdown_to_slack_code_eaw_spacing():
+    for content, expected in [
+        ("中文`程式`中文", "中文 `程式` 中文"),
+        ("中文```程式```中文", "中文 ```程式``` 中文"),
+        ("括號：「`程式`」", "括號：「 `程式` 」"),
+    ]:
+        result = markdown_to_slack(content)
+        assert result == expected


### PR DESCRIPTION
Insert a single ASCII space before and after Slack formatting markers and backtick code spans/blocks when they adjoin East Asian wide characters or fullwidth punctuation. Detection uses Unicode East Asian Width (W/F) and covers Chinese, Japanese, Korean, Bopomofo, and fullwidth punctuation.

Keep code content intact by only adjusting spaces outside backticks.

Examples:
```
- 這是**粗體**文字。 -> 這是 *粗體* 文字。
- ひらがな**強調**ひらがな -> ひらがな *強調* ひらがな
- 한글**강조**한글 -> 한글 *강조* 한글
- 中文`程式`中文 -> 中文 `程式` 中文
- 中文```程式```中文 -> 中文 ```程式``` 中文
- 括號：「`程式`」 -> 括號：「 `程式` 」
```

Add tests for spacing around markers and backticks, and exclude halfwidth Katakana neighbors.

Summary from GitHub Copilot:

> This pull request enhances the `markdown_to_slack` function to improve readability when Slack formatting markers or code spans are adjacent to East Asian wide or fullwidth characters. It inserts ASCII spaces in these cases, ensuring better rendering in Slack. Comprehensive tests are added to verify correct behavior for various CJK and fullwidth character scenarios.
> 
> Formatting and spacing improvements for East Asian characters:
> 
> * Updated `markdown_to_slack` in `app/markdown_conversion.py` to insert spaces around code spans/blocks and Slack formatting markers (bold, italic, strikethrough) when adjacent to East Asian wide/fullwidth characters, improving mrkdwn rendering. [[1]](diffhunk://#diff-2170a6249c7403e4e8466133f0c88c38f7352e09ba1e16ed34e94602a01b7be2L34-R55) [[2]](diffhunk://#diff-2170a6249c7403e4e8466133f0c88c38f7352e09ba1e16ed34e94602a01b7be2R71-R106)
> * Imported the `unicodedata` module to support detection of East Asian character widths.
> 
> Testing enhancements:
> 
> * Added `test_markdown_to_slack_eaw_spacing` and `test_markdown_to_slack_code_eaw_spacing` in `tests/markdown_conversion_test.py` to ensure correct spacing is applied for CJK, fullwidth, and halfwidth characters, as well as for code spans.