### PR TITLE
Add chat-latest model option with API and image support

### DIFF
--- a/app/openai_api_utils.py
+++ b/app/openai_api_utils.py
@@ -39,7 +39,7 @@ def normalize_base_url(value: Optional[str]) -> Optional[str]:
 def token_budget_kwarg(model: Optional[str], budget: int) -> Dict[str, int]:
     """Returns the correct token budget kwarg for the given model."""
     should_use_completion_tokens = (
-        model and model.lower().startswith("gpt-5")
+        model == "chat-latest" or (model and model.lower().startswith("gpt-5"))
     ) or is_reasoning_model(model)
 
     return (
@@ -56,7 +56,7 @@ def sampling_kwargs(
     ml = model.lower() if model else ""
     if is_reasoning_model(model) or is_search_model(model):
         return {}
-    if ml.startswith(("gpt-5.1", "gpt-5.2", "gpt-5.3")):
+    if model == "chat-latest" or ml.startswith(("gpt-5.1", "gpt-5.2", "gpt-5.3")):
         return {}
     return {
         "temperature": temperature,

--- a/app/openai_constants.py
+++ b/app/openai_constants.py
@@ -27,6 +27,7 @@ GPT_4_1_MINI_MODEL = "gpt-4.1-mini"
 GPT_4_1_MINI_2025_04_14_MODEL = "gpt-4.1-mini-2025-04-14"
 GPT_4_1_NANO_MODEL = "gpt-4.1-nano"
 GPT_4_1_NANO_2025_04_14_MODEL = "gpt-4.1-nano-2025-04-14"
+CHAT_LATEST_MODEL = "chat-latest"
 GPT_5_CHAT_LATEST_MODEL = "gpt-5-chat-latest"
 GPT_5_SEARCH_API_MODEL = "gpt-5-search-api"
 GPT_5_SEARCH_API_2025_10_14_MODEL = "gpt-5-search-api-2025-10-14"
@@ -90,6 +91,8 @@ MODEL_TOKENS = {
     GPT_4O_2024_05_13_MODEL: (3, 1),
     # GPT-4o mini
     GPT_4O_MINI_2024_07_18_MODEL: (3, 1),
+    # ChatGPT latest
+    CHAT_LATEST_MODEL: (3, 1),
     # GPT-5 chat latest
     GPT_5_CHAT_LATEST_MODEL: (3, 1),
     GPT_5_1_CHAT_LATEST_MODEL: (3, 1),
@@ -162,6 +165,8 @@ MODEL_CONTEXT_LENGTHS = {
     GPT_4_1_2025_04_14_MODEL: 1048576,
     GPT_4_1_MINI_2025_04_14_MODEL: 1048576,
     GPT_4_1_NANO_2025_04_14_MODEL: 1048576,
+    # ChatGPT latest
+    CHAT_LATEST_MODEL: 400000,
     # GPT-5 chat latest
     GPT_5_CHAT_LATEST_MODEL: 128000,
     GPT_5_1_CHAT_LATEST_MODEL: 128000,

--- a/app/slack_ops.py
+++ b/app/slack_ops.py
@@ -371,7 +371,10 @@ def can_send_image_url_to_openai(context: BoltContext) -> bool:
     openai_model = context.get("OPENAI_MODEL")
     # More supported models will come. This logic will need to be updated then.
     can_send_image_url = openai_model is not None and (
-        openai_model.startswith("gpt-4o") or openai_model.startswith("gpt-4.1") or openai_model.startswith("gpt-5")
+        openai_model == "chat-latest"
+        or openai_model.startswith("gpt-4o")
+        or openai_model.startswith("gpt-4.1")
+        or openai_model.startswith("gpt-5")
     )
     return can_send_image_url
 

--- a/app/slack_ui.py
+++ b/app/slack_ui.py
@@ -13,6 +13,7 @@ from app.openai_constants import (
     GPT_5_4_MINI_MODEL,
     GPT_5_4_NANO_MODEL,
     GPT_5_5_MODEL,
+    CHAT_LATEST_MODEL,
     GPT_5_2_CHAT_LATEST_MODEL,
     GPT_5_2_MODEL,
     GPT_5_1_CHAT_LATEST_MODEL,
@@ -452,6 +453,10 @@ def build_configure_modal(context: BoltContext) -> dict:
         {
             "text": {"type": "plain_text", "text": "GPT-5.5"},
             "value": GPT_5_5_MODEL,
+        },
+        {
+            "text": {"type": "plain_text", "text": "chat-latest"},
+            "value": CHAT_LATEST_MODEL,
         },
         {
             "text": {"type": "plain_text", "text": "GPT-5.4"},

--- a/tests/model_constants_test.py
+++ b/tests/model_constants_test.py
@@ -4,6 +4,7 @@ from app.openai_constants import (
     MODEL_FALLBACKS,
     MODEL_TOKENS,
     MODEL_CONTEXT_LENGTHS,
+    CHAT_LATEST_MODEL,
     GPT_4_MODEL,
     GPT_4_0613_MODEL,
     GPT_5_1_MODEL,
@@ -48,6 +49,20 @@ def test_gpt_5_4_nano_alias_resolution():
 def test_gpt_5_5_alias_resolution():
     """Ensures the GPT-5.5 alias resolves to the dated release."""
     assert resolve_model_alias(GPT_5_5_MODEL) == GPT_5_5_2026_04_23_MODEL
+
+def test_chat_latest_model_support():
+    """Ensures chat-latest has direct token and context definitions."""
+    from app.openai_ops import calculate_num_tokens, context_length
+
+    assert resolve_model_alias(CHAT_LATEST_MODEL) == CHAT_LATEST_MODEL
+    assert CHAT_LATEST_MODEL not in MODEL_FALLBACKS
+    assert MODEL_TOKENS[CHAT_LATEST_MODEL] == (3, 1)
+    assert MODEL_CONTEXT_LENGTHS[CHAT_LATEST_MODEL] == 400000
+    assert context_length(CHAT_LATEST_MODEL) == 400000
+    assert calculate_num_tokens(
+        messages=[{"role": "user", "content": "hello"}],
+        model=CHAT_LATEST_MODEL,
+    ) > 0
 
 def test_unregistered_model_fails():
     """Tests that resolving an unregistered model raises NotImplementedError."""

--- a/tests/openai_api_utils_test.py
+++ b/tests/openai_api_utils_test.py
@@ -29,3 +29,11 @@ def test_sampling_and_token_budget_for_gpt_5_5():
 
     assert token_kwargs == {"max_completion_tokens": 1024}
     assert sampling == {}
+
+
+def test_sampling_and_token_budget_for_chat_latest():
+    token_kwargs = api_utils.token_budget_kwarg("chat-latest", 1024)
+    sampling = api_utils.sampling_kwargs("chat-latest", 0.75)
+
+    assert token_kwargs == {"max_completion_tokens": 1024}
+    assert sampling == {}

--- a/tests/openai_ops_test.py
+++ b/tests/openai_ops_test.py
@@ -156,6 +156,7 @@ def test_messages_within_context_window_passes_model(monkeypatch):
 @pytest.mark.parametrize(
     "model,expected",
     [
+        ("chat-latest", False),
         ("gpt-5-chat-latest", False),
         ("gpt-5.1-chat-latest", False),
         ("gpt-5.2-chat-latest", False),
@@ -183,6 +184,7 @@ def test_is_reasoning_heuristics(model, expected):
 @pytest.mark.parametrize(
     "model,is_reasoning,temperature,timeout,user",
     [
+        ("chat-latest", False, 0.6, 10, "U111"),
         (GPT_4O_MODEL, False, 0.7, 12, "U123"),
         ("o3", True, 1.0, 5, "U234"),
         (GPT_5_SEARCH_API_MODEL, False, 0.5, 8, "U345"),
@@ -248,7 +250,10 @@ def test_sync_tokens_and_sampling_behavior(
         ):
             assert k not in kwargs
     else:
-        if kwargs.get("model", "").lower().startswith("gpt-5"):
+        if kwargs.get("model") == "chat-latest":
+            assert token_key == "max_completion_tokens"
+            assert kwargs.get("max_completion_tokens") == MAX_TOKENS
+        elif kwargs.get("model", "").lower().startswith("gpt-5"):
             assert token_key == "max_completion_tokens"
             assert kwargs.get("max_completion_tokens") == MAX_TOKENS
         else:
@@ -266,7 +271,9 @@ def test_sync_tokens_and_sampling_behavior(
             if k in kwargs
         }
         ml = kwargs.get("model", "").lower()
-        if ml.startswith(("gpt-5.1", "gpt-5.2", "gpt-5.3")):
+        if kwargs.get("model") == "chat-latest":
+            assert sampling_keys == set()
+        elif ml.startswith(("gpt-5.1", "gpt-5.2", "gpt-5.3")):
             assert sampling_keys == set()
         elif ml.startswith("gpt-5"):
             assert sampling_keys == {

--- a/tests/slack_ops_test.py
+++ b/tests/slack_ops_test.py
@@ -24,11 +24,26 @@ def reset_reply_cache():
     slack_ops._CACHE._last_sent.clear()
 
 
+def make_context(*, model, bot_scopes=("files:read",)):
+    context = MagicMock()
+    context.authorize_result.bot_scopes = list(bot_scopes)
+    context.get.side_effect = lambda key, default=None: {"OPENAI_MODEL": model}.get(key, default)
+    return context
+
+
 def make_client(chat_update_side_effect=None):
     client = MagicMock()
     client.chat_update = MagicMock(side_effect=chat_update_side_effect)
     client.chat_postMessage = MagicMock()
     return client
+
+
+def test_can_send_image_url_to_openai_allows_chat_latest(monkeypatch):
+    monkeypatch.setattr(slack_ops, "IMAGE_FILE_ACCESS_ENABLED", True)
+
+    assert slack_ops.can_send_image_url_to_openai(
+        make_context(model="chat-latest")
+    ) is True
 
 
 def test_final_short_updates_in_place():

--- a/tests/slack_ui_test.py
+++ b/tests/slack_ui_test.py
@@ -7,6 +7,7 @@ from app.openai_constants import (
     GPT_5_4_MINI_MODEL,
     GPT_5_4_NANO_MODEL,
     GPT_5_5_MODEL,
+    CHAT_LATEST_MODEL,
 )
 
 
@@ -30,8 +31,9 @@ def test_build_configure_modal_includes_new_models():
     options = modal["blocks"][1]["element"]["options"]
     values = [option["value"] for option in options]
 
-    assert values[:7] == [
+    assert values[:8] == [
         GPT_5_5_MODEL,
+        CHAT_LATEST_MODEL,
         GPT_5_4_MODEL,
         GPT_5_4_MINI_MODEL,
         GPT_5_4_NANO_MODEL,


### PR DESCRIPTION
Add the floating ChatGPT Instant model alias to the supported model list using the official chat-latest model page for the model ID, Chat Completions availability, image input support, and context window.

Reference: https://developers.openai.com/api/docs/models/chat-latest